### PR TITLE
Temporary fix for CallKit session not ended when onDisconnected and onFail

### DIFF
--- a/ios/RNTwilioVoice/RNTwilioVoice.m
+++ b/ios/RNTwilioVoice/RNTwilioVoice.m
@@ -333,9 +333,9 @@ RCT_REMAP_METHOD(getActiveCall,
     [params setObject:StateDisconnected forKey:@"call_state"];
   }
   [self sendEventWithName:@"connectionDidDisconnect" body:params];
-  if (self.call.state == TVOCallStateConnected) {
-    [self performEndCallActionWithUUID:call.uuid];
-  }
+
+  [self performEndCallActionWithUUID:call.uuid];
+
   self.call = nil;
 }
 
@@ -360,9 +360,8 @@ RCT_REMAP_METHOD(getActiveCall,
   }
   [self sendEventWithName:@"connectionDidDisconnect" body:params];
 
-  if (self.call.state == TVOCallStateConnected) {
-    [self performEndCallActionWithUUID:call.uuid];
-  }
+  [self performEndCallActionWithUUID:call.uuid];
+
   self.call = nil;
 }
 


### PR DESCRIPTION
This is a temporary fix for fixing the `CallKit` session not ended when the call is disconnected from the other party and when the call is failed.

This temporary fix I got from this PR: https://github.com/hoxfon/react-native-twilio-programmable-voice/pull/30
